### PR TITLE
fix: move jar from /usr/bin to /usr/share to follow the FHS standard

### DIFF
--- a/carbonio-message-dispatcher-auth/pom.xml
+++ b/carbonio-message-dispatcher-auth/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.message.dispatcher</groupId>
     <artifactId>carbonio-message-dispatcher</artifactId>
-    <version>0.14.1</version>
+    <version>0.14.2</version>
   </parent>
 
   <artifactId>carbonio-message-dispatcher-auth</artifactId>

--- a/carbonio-message-dispatcher-auth/src/main/java/com/zextras/carbonio/message/dispatcher/auth/Boot.java
+++ b/carbonio-message-dispatcher-auth/src/main/java/com/zextras/carbonio/message/dispatcher/auth/Boot.java
@@ -9,30 +9,25 @@ import com.zextras.carbonio.message.dispatcher.auth.service.AuthenticationServic
 import com.zextras.carbonio.message.dispatcher.auth.service.impl.AuthenticationServiceImpl;
 import com.zextras.carbonio.message.dispatcher.auth.web.api.CheckPasswordApi;
 import com.zextras.carbonio.message.dispatcher.auth.web.api.HealthApi;
+import com.zextras.carbonio.message.dispatcher.auth.web.api.UserExistsApi;
 import com.zextras.carbonio.usermanagement.UserManagementClient;
-
 import java.net.InetSocketAddress;
 import javax.servlet.ServletRegistration.Dynamic;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.zextras.carbonio.message.dispatcher.auth.web.api.UserExistsApi;
 
 public class Boot {
 
   private final AuthenticationService authenticationService;
 
-  public Boot(){
+  public Boot() {
     this.authenticationService = new AuthenticationServiceImpl(getUserManagementClient());
   }
 
   private UserManagementClient getUserManagementClient() {
     return UserManagementClient.atURL(
-      String.format("http://%s:%s",
-        Constant.SERVER_HOST,
-        Constant.USER_MANAGEMENT_PORT));
+        String.format("http://%s:%s", Constant.SERVER_HOST, Constant.USER_MANAGEMENT_PORT));
   }
 
   public void boot() throws Exception {
@@ -40,19 +35,23 @@ public class Boot {
     ContextHandlerCollection handlers = new ContextHandlerCollection();
     ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
 
-    context.addServletContainerInitializer((c, ctx) -> {
-      Dynamic checkPassword = ctx.addServlet("CheckPasswordServlet",
-        CheckPasswordApi.create(authenticationService));
-      checkPassword.addMapping("/check_password");
-    });
-    context.addServletContainerInitializer((c, ctx) -> {
-      Dynamic userExists = ctx.addServlet("UserExistsServlet", UserExistsApi.create(authenticationService));
-      userExists.addMapping("/user_exists");
-    });
-    context.addServletContainerInitializer((c, ctx) -> {
-      Dynamic health = ctx.addServlet("HealthServlet", HealthApi.create());
-      health.addMapping("/health/ready");
-    });
+    context.addServletContainerInitializer(
+        (c, ctx) -> {
+          Dynamic checkPassword =
+              ctx.addServlet(
+                  "CheckPasswordServlet", CheckPasswordApi.create(authenticationService));
+          checkPassword.addMapping("/check_password");
+        });
+    context.addServletContainerInitializer(
+        (c, ctx) -> {
+          Dynamic userExists = ctx.addServlet("UserExistsServlet", UserExistsApi.create());
+          userExists.addMapping("/user_exists");
+        });
+    context.addServletContainerInitializer(
+        (c, ctx) -> {
+          Dynamic health = ctx.addServlet("HealthServlet", HealthApi.create());
+          health.addMapping("/health/ready");
+        });
     handlers.addHandler(context);
     server.setHandler(handlers);
     server.start();

--- a/carbonio-message-dispatcher-auth/src/main/java/com/zextras/carbonio/message/dispatcher/auth/web/api/CheckPasswordApi.java
+++ b/carbonio-message-dispatcher-auth/src/main/java/com/zextras/carbonio/message/dispatcher/auth/web/api/CheckPasswordApi.java
@@ -8,7 +8,6 @@ import com.zextras.carbonio.message.dispatcher.auth.exception.FailedDependencyEx
 import com.zextras.carbonio.message.dispatcher.auth.exception.UnauthorizedException;
 import com.zextras.carbonio.message.dispatcher.auth.service.AuthenticationService;
 import com.zextras.carbonio.message.dispatcher.auth.utility.Utilities;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import javax.servlet.http.HttpServlet;
@@ -28,7 +27,7 @@ public class CheckPasswordApi extends HttpServlet {
   }
 
   @Override
-  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     Map<String, String> queryItems = Utilities.getQueryItems(request.getQueryString());
     String user = queryItems.get("user");
     String token = queryItems.get("pass");
@@ -38,7 +37,6 @@ public class CheckPasswordApi extends HttpServlet {
       return;
     }
     try {
-
       Optional<String> userId = authenticationService.validateToken(token);
       if (userId.isPresent()) {
         if (userId.get().equals(user)) {

--- a/carbonio-message-dispatcher-auth/src/main/java/com/zextras/carbonio/message/dispatcher/auth/web/api/UserExistsApi.java
+++ b/carbonio-message-dispatcher-auth/src/main/java/com/zextras/carbonio/message/dispatcher/auth/web/api/UserExistsApi.java
@@ -4,7 +4,6 @@
 
 package com.zextras.carbonio.message.dispatcher.auth.web.api;
 
-import com.zextras.carbonio.message.dispatcher.auth.service.AuthenticationService;
 import java.io.IOException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -12,18 +11,15 @@ import javax.servlet.http.HttpServletResponse;
 
 public class UserExistsApi extends HttpServlet {
 
-  private final AuthenticationService authenticationService;
+  public UserExistsApi() {}
 
-  public UserExistsApi(AuthenticationService authenticationService) {
-    this.authenticationService = authenticationService;
-  }
-
-  public static UserExistsApi create(AuthenticationService authenticationService) {
-    return new UserExistsApi(authenticationService);
+  public static UserExistsApi create() {
+    return new UserExistsApi();
   }
 
   @Override
-  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+  protected void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
     response.getWriter().print(true);
     response.setContentLength(4);
     response.setStatus(200);

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -131,7 +131,7 @@ build() {
 
 package() {
   cd "${srcdir}"/../../dispatcher/carbonio-message-dispatcher-auth/target
-  install -Dm 644 ./carbonio-message-dispatcher-auth-fatjar.jar \
+  install -Dm 755 ./carbonio-message-dispatcher-auth-fatjar.jar \
     "${pkgdir}/usr/share/carbonio/carbonio-message-dispatcher-auth.jar"
 
   cd "${srcdir}"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-message-dispatcher"
-pkgver="0.14.1"
+pkgver="0.14.2"
 pkgrel="1"
 pkgdesc="Carbonio Message Dispatcher component"
 maintainer="Zextras <packages@zextras.com>"
@@ -36,18 +36,23 @@ makedepends__yum=(
 
 source=(
   "https://github.com/esl/MongooseIM/archive/6.2.1.tar.gz"
+  "mongooseim.toml"
+  "app.config"
   "configure.vars.config"
-  "carbonio-message-dispatcher"
-  "carbonio-message-dispatcher-http.hcl"
-  "carbonio-message-dispatcher-xmpp.hcl"
-  "carbonio-message-dispatcher-auth.hcl"
+  "mod_event_pusher_http_defaults.patch"
+  "carbonio-message-dispatcher-auth"
+  "carbonio-message-dispatcher-migration"
+  "carbonio-message-dispatcher-setup"
+  "carbonio-message-dispatcher-pending-setup"
   "carbonio-message-dispatcher.service"
+  "carbonio-message-dispatcher-auth.service"
   "carbonio-message-dispatcher-http-sidecar.service"
   "carbonio-message-dispatcher-xmpp-sidecar.service"
   "carbonio-message-dispatcher-auth-sidecar.service"
-  "carbonio-message-dispatcher-setup.sh"
-  "mongooseim.toml"
-  "app.config"
+  "carbonio-message-dispatcher-http.hcl"
+  "carbonio-message-dispatcher-xmpp.hcl"
+  "carbonio-message-dispatcher-auth.hcl"
+  "logback.xml"
   "intentions-http.json"
   "intentions-xmpp.json"
   "intentions-auth.json"
@@ -55,36 +60,37 @@ source=(
   "service-protocol-http.json"
   "service-protocol-xmpp.json"
   "service-protocol-auth.json"
-  "carbonio-message-dispatcher-auth.service"
-  "logback.xml"
-  "carbonio-message-dispatcher-migration"
   "pgsql-script-initial-schema-mongooseim-6.0.0.sql"
   "pgsql-script-migrations-6.0.0.sql"
   "pgsql-script-migrations-6.2.0.sql"
   "pgsql-script-migrations-6.2.1.sql"
-  "mod_event_pusher_http_defaults.patch"
 )
 backup=(
-  "etc/zextras/service-discover/carbonio-message-dispatcher-http.hcl"
-  "etc/zextras/service-discover/carbonio-message-dispatcher-xmpp.hcl"
-  "etc/zextras/service-discover/carbonio-message-dispatcher-auth.hcl"
   "etc/carbonio/message-dispatcher/mongooseim.toml"
   "etc/carbonio/message-dispatcher/app.config"
   "etc/carbonio/message-dispatcher/logback.xml"
+  "etc/zextras/service-discover/carbonio-message-dispatcher-http.hcl"
+  "etc/zextras/service-discover/carbonio-message-dispatcher-xmpp.hcl"
+  "etc/zextras/service-discover/carbonio-message-dispatcher-auth.hcl"
 )
 sha256sums=('662999119c20792e959d479ccdf530b6c0cea11e44eafd069df6ef98fe89bc52'
+  'c764d96bb0e405d4ba8d7155d068b7cf974360c57389184310bc38aae7b20335'
+  'f7384b4fd538b267f8c7a708185a9c56f5444ec04526d4b85ca5068f538d1abc'
   'a55ee89a02e901831baf61faa3b22127ae93e4cccac8d6f1032bfa4202985089'
-  '653a9deeabf6fde20002cd36956eb6f4afff3cfa34ad334008642c5cd967b3a5'
-  '9ee13ade0e7765928ae1fdd9240e45b66fd2e31eb86a0c17e868c1bb84a75947'
-  '0312bb4d66fd0ed34dfa4dc9f38bb253ed6822c71390cd2a858b36bb239a2523'
-  'cacd071dbc925739256cfd82f16ed0d71a6e98849b77eb3d37c3375f9a6ec466'
+  '5c8d45d303f15dd9d9b734b2803ddf1cc763546d9ca0e0e742c88c1654258b32'
+  'fc36795b485260f2048bf6802f942be0e427c57a09b020b33be457b655a98625'
+  '692079ea85e441db8565b1fbc38b460d4f36136d598d7d14c51c1885896e3053'
+  '8a06d1f97c290e818951b5f38bd38b63ab51dfd641f433cd2f0b84905edcd0b1'
+  '38c979389729d127887c2da1b23bf5114e2ad9bdc211c8315f87da745b4488d1'
   '70bb89623bf7deaafe9cdb612ed95189df56da3ecc35882f46323483167b44f7'
+  '6fc87dbdc9438ebea66e29231a3040fdcfdce47338cd6326f5b3cdf96e98e18c'
   'f67030cf61ef5f2a2d674cd6f1deda739cce8c466f8119f4a072ca8c8ab77ffa'
   'f1a8921e21ff8c5eb36640f86f1494d59cc20422759718737eb8523a43cab1b9'
   'b83a5db0970e38198f847d311e627c599f28051cfb0dff4721c57277efb40641'
-  '656208c6908eacf2147bff0a40c3f4a71763ac505702099a46c3d95967a55ce4'
-  'c764d96bb0e405d4ba8d7155d068b7cf974360c57389184310bc38aae7b20335'
-  'f7384b4fd538b267f8c7a708185a9c56f5444ec04526d4b85ca5068f538d1abc'
+  '9ee13ade0e7765928ae1fdd9240e45b66fd2e31eb86a0c17e868c1bb84a75947'
+  '0312bb4d66fd0ed34dfa4dc9f38bb253ed6822c71390cd2a858b36bb239a2523'
+  'cacd071dbc925739256cfd82f16ed0d71a6e98849b77eb3d37c3375f9a6ec466'
+  'd1ec2c67cd15263fc84ffb891f4276d1e147084a3e4eb1bc1801de2ca5bf32e4'
   'c5a04071a24f45f79d28135b79da396a607baf587d880f66f94d6afee77070b3'
   '7daba3df5207eeebc90b8754f34d669360de14c29404359bb6e782434253438a'
   '4c6e3661865d28018f2f5049746389008d3f6bb8a7e5821604c684592f410e07'
@@ -92,14 +98,10 @@ sha256sums=('662999119c20792e959d479ccdf530b6c0cea11e44eafd069df6ef98fe89bc52'
   '58bf32b3212d9333edaec81260121a460c738ede9be5a26c29bd0a0f3c0ee3e9'
   'c310dee43435bf572532f49947e87e0c33605a43b5ed0980606e147d6fc1e0a5'
   'ecca7efddcff1a5efe6d38fd64bf489638bdac94c6c5ec7178866354a9ad5a91'
-  'f0a34329d96bd02455c5039934fac131177af7eb99b8c1bcb3bf91395c370ab3'
-  'd1ec2c67cd15263fc84ffb891f4276d1e147084a3e4eb1bc1801de2ca5bf32e4'
-  '692079ea85e441db8565b1fbc38b460d4f36136d598d7d14c51c1885896e3053'
   'a32f61262ba7a51ba268c41801684c26668fadea676ae8e0f90e38bd754d1455'
   'cf583dd0a4ccd21fdb04a4600792657a762609b3cda4322252643d3ee28e3002'
   'f223f80047745435b2114430edf7d21e1fb288f28cc90180fb812e2a51341db8'
-  '846614d16daa0391ae156ad22697bc62f366cd5bbfce45af7fb6328284d23147'
-  '5c8d45d303f15dd9d9b734b2803ddf1cc763546d9ca0e0e742c88c1654258b32')
+  '846614d16daa0391ae156ad22697bc62f366cd5bbfce45af7fb6328284d23147')
 
 build() {
   cd "${srcdir}/MongooseIM-6.2.1"
@@ -130,20 +132,41 @@ build() {
 package() {
   cd "${srcdir}"/../../dispatcher/carbonio-message-dispatcher-auth/target
   install -Dm 644 ./carbonio-message-dispatcher-auth-fatjar.jar \
-    "${pkgdir}/opt/zextras/lib/jars/carbonio-message-dispatcher-auth.jar"
+    "${pkgdir}/usr/share/carbonio/carbonio-message-dispatcher-auth.jar"
 
   cd "${srcdir}"
+
   #Overwriting mongoose files with ours
   install -Dm 644 mongooseim.toml \
     "${pkgdir}/etc/carbonio/message-dispatcher/mongooseim.toml"
   install -Dm 644 app.config \
     "${pkgdir}/etc/carbonio/message-dispatcher/app.config"
 
+  #Log files
+  install -d "${pkgdir}/opt/zextras/common/lib/mongooseim/log"
+  touch "${pkgdir}/opt/zextras/common/lib/mongooseim/log/console.log"
+  touch "${pkgdir}/opt/zextras/common/lib/mongooseim/log/error.log"
+  touch "${pkgdir}/opt/zextras/common/lib/mongooseim/log/crash.log"
+
+  #Args files
+  cp "${pkgdir}/opt/zextras/common/lib/mongooseim/releases/6.2.1/vm.args" \
+    "${pkgdir}/etc/carbonio/message-dispatcher/vm.args"
+  cp "${pkgdir}/opt/zextras/common/lib/mongooseim/etc/vm.dist.args.example" \
+    "${pkgdir}/etc/carbonio/message-dispatcher/vm.dist.args"
+
   #Our files
-  install -Dm 755 carbonio-message-dispatcher \
-    "${pkgdir}/usr/bin/carbonio-message-dispatcher"
+  install -Dm 755 carbonio-message-dispatcher-auth \
+    "${pkgdir}/usr/bin/carbonio-message-dispatcher-auth"
+  install -Dm 755 carbonio-message-dispatcher-migration \
+    "${pkgdir}/usr/bin/carbonio-message-dispatcher-migration"
+  install -Dm 755 carbonio-message-dispatcher-setup \
+    "${pkgdir}/usr/bin/carbonio-message-dispatcher-setup"
+  install -Dm 644 carbonio-message-dispatcher-pending-setup \
+    "${pkgdir}/etc/zextras/pending-setups.d/carbonio-message-dispatcher.sh"
   install -Dm 644 carbonio-message-dispatcher.service \
     "${pkgdir}/lib/systemd/system/carbonio-message-dispatcher.service"
+  install -Dm 644 carbonio-message-dispatcher-auth.service \
+    "${pkgdir}/lib/systemd/system/carbonio-message-dispatcher-auth.service"
   install -Dm 644 carbonio-message-dispatcher-http-sidecar.service \
     "${pkgdir}/lib/systemd/system/carbonio-message-dispatcher-http-sidecar.service"
   install -Dm 644 carbonio-message-dispatcher-xmpp-sidecar.service \
@@ -156,8 +179,8 @@ package() {
     "${pkgdir}/etc/zextras/service-discover/carbonio-message-dispatcher-xmpp.hcl"
   install -Dm 644 carbonio-message-dispatcher-auth.hcl \
     "${pkgdir}/etc/zextras/service-discover/carbonio-message-dispatcher-auth.hcl"
-  install -Dm 644 carbonio-message-dispatcher-setup.sh \
-    "${pkgdir}/etc/zextras/pending-setups.d/carbonio-message-dispatcher.sh"
+  install -Dm 644 logback.xml \
+    "${pkgdir}/etc/carbonio/message-dispatcher/logback.xml"
   install -Dm 644 intentions-http.json \
     "${pkgdir}/etc/carbonio/message-dispatcher/service-discover/intentions-http.json"
   install -Dm 644 intentions-xmpp.json \
@@ -172,13 +195,8 @@ package() {
     "${pkgdir}/etc/carbonio/message-dispatcher/service-discover/service-protocol-xmpp.json"
   install -Dm 644 service-protocol-auth.json \
     "${pkgdir}/etc/carbonio/message-dispatcher/service-discover/service-protocol-auth.json"
-  install -Dm 644 carbonio-message-dispatcher-auth.service \
-    "${pkgdir}/lib/systemd/system/carbonio-message-dispatcher-auth.service"
-  install -Dm 644 logback.xml \
-    "${pkgdir}/etc/carbonio/message-dispatcher/logback.xml"
 
-  install -Dm 755 carbonio-message-dispatcher-migration \
-    "${pkgdir}/usr/bin/carbonio-message-dispatcher-migration"
+  #Migration files
   install -Dm 644 pgsql-script-initial-schema-mongooseim-6.0.0.sql \
     "${pkgdir}/etc/carbonio/message-dispatcher/sql-scripts/initial-schema.sql"
   install -Dm 644 pgsql-script-migrations-6.0.0.sql \
@@ -187,14 +205,6 @@ package() {
     "${pkgdir}/etc/carbonio/message-dispatcher/sql-scripts/migrations/6.2.0.sql"
   install -Dm 644 pgsql-script-migrations-6.2.1.sql \
       "${pkgdir}/etc/carbonio/message-dispatcher/sql-scripts/migrations/6.2.1.sql"
-
-  cp "${pkgdir}/opt/zextras/common/lib/mongooseim/releases/6.2.1/vm.args" \
-    "${pkgdir}/etc/carbonio/message-dispatcher/vm.args"
-
-  cp "${pkgdir}/opt/zextras/common/lib/mongooseim/etc/vm.dist.args.example" \
-    "${pkgdir}/etc/carbonio/message-dispatcher/vm.dist.args"
-
-  install -d "${pkgdir}/opt/zextras/common/lib/mongooseim/log"
 }
 
 postinst() {
@@ -208,14 +218,17 @@ postinst() {
   chown carbonio-message-dispatcher:carbonio-message-dispatcher /var/lock/carbonio/message-dispatcher
   chown carbonio-message-dispatcher:carbonio-message-dispatcher /var/lib/carbonio/message-dispatcher
   chown carbonio-message-dispatcher:carbonio-message-dispatcher /opt/zextras/common/lib/mongooseim/log
+  chown carbonio-message-dispatcher:carbonio-message-dispatcher /opt/zextras/common/lib/mongooseim/log/console.log
+  chown carbonio-message-dispatcher:carbonio-message-dispatcher /opt/zextras/common/lib/mongooseim/log/error.log
+  chown carbonio-message-dispatcher:carbonio-message-dispatcher /opt/zextras/common/lib/mongooseim/log/crash.log
 
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl enable carbonio-message-dispatcher-auth.service >/dev/null 2>&1 || :
     systemctl enable carbonio-message-dispatcher.service >/dev/null 2>&1 || :
+    systemctl enable carbonio-message-dispatcher-auth-sidecar.service >/dev/null 2>&1 || :
     systemctl enable carbonio-message-dispatcher-http-sidecar.service >/dev/null 2>&1 || :
     systemctl enable carbonio-message-dispatcher-xmpp-sidecar.service >/dev/null 2>&1 || :
-    systemctl enable carbonio-message-dispatcher-auth-sidecar.service >/dev/null 2>&1 || :
   fi
 
   echo "======================================================"
@@ -226,16 +239,16 @@ postinst() {
 
 prerm() {
   if [ -d /run/systemd/system ]; then
+    systemctl --no-reload disable carbonio-message-dispatcher-auth.service >/dev/null 2>&1 || :
+    systemctl --no-reload disable carbonio-message-dispatcher-auth-sidecar.service >/dev/null 2>&1 || :
     systemctl --no-reload disable carbonio-message-dispatcher.service >/dev/null 2>&1 || :
     systemctl --no-reload disable carbonio-message-dispatcher-http-sidecar.service >/dev/null 2>&1 || :
     systemctl --no-reload disable carbonio-message-dispatcher-xmpp-sidecar.service >/dev/null 2>&1 || :
-    systemctl --no-reload disable carbonio-message-dispatcher-auth-sidecar.service >/dev/null 2>&1 || :
-    systemctl --no-reload disable carbonio-message-dispatcher-auth.service >/dev/null 2>&1 || :
+    systemctl stop carbonio-message-dispatcher-auth.service >/dev/null 2>&1 || :
+    systemctl stop carbonio-message-dispatcher-auth-sidecar.service >/dev/null 2>&1 || :
     systemctl stop carbonio-message-dispatcher.service >/dev/null 2>&1 || :
     systemctl stop carbonio-message-dispatcher-http-sidecar.service >/dev/null 2>&1 || :
     systemctl stop carbonio-message-dispatcher-xmpp-sidecar.service >/dev/null 2>&1 || :
-    systemctl stop carbonio-message-dispatcher-auth-sidecar.service >/dev/null 2>&1 || :
-    systemctl stop carbonio-message-dispatcher-auth.service >/dev/null 2>&1 || :
   fi
 }
 

--- a/package/carbonio-message-dispatcher-auth
+++ b/package/carbonio-message-dispatcher-auth
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+JAVA_HOME="/usr/share/carbonio/message-dispatcher:/opt/zextras/common/lib/jvm/java"
+export JAVA_HOME
+/opt/zextras/common/bin/java \
+  -Djava.net.preferIPv4Stack=true \
+  -jar /usr/share/carbonio/carbonio-message-dispatcher-auth.jar

--- a/package/carbonio-message-dispatcher-auth.service
+++ b/package/carbonio-message-dispatcher-auth.service
@@ -7,7 +7,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zextras/common/bin/java -Djava.net.preferIPv4Stack=true -jar /opt/zextras/lib/jars/carbonio-message-dispatcher-auth.jar
+ExecStart=/usr/bin/carbonio-message-dispatcher-auth
 User=carbonio-message-dispatcher
 Group=carbonio-message-dispatcher
 Restart=on-failure

--- a/package/carbonio-message-dispatcher-pending-setup
+++ b/package/carbonio-message-dispatcher-pending-setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+carbonio-message-dispatcher-setup

--- a/package/carbonio-message-dispatcher-setup
+++ b/package/carbonio-message-dispatcher-setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -10,11 +10,6 @@
 if [[ $(id -u) -ne 0 ]]; then
   echo "Please run as root"
   exit 1
-fi
-
-if [[ "$1" != "setup" ]]; then
-  echo "Syntax: 'carbonio-message-dispatcher setup' to automatically configure the service"
-  exit 1;
 fi
 
 MAIN_SERVICE_NAME="carbonio-message-dispatcher"
@@ -30,6 +25,7 @@ config_variant() {
 # --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
 # to avoid re-asking for the password
 echo -n "Insert the cluster credential password: "
+# shellcheck disable=SC2155
 export CONSUL_HTTP_TOKEN=$(service-discover bootstrap-token --setup)
 EXIT_CODE="$?"
 echo ""
@@ -45,6 +41,7 @@ POLICY_DESCRIPTION='Carbonio Message Dispatcher policy for service and sidecar p
 
 # Create or update policy for the specific service (this will be shared across cluster)
 consul acl policy create -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules  @/etc/carbonio/message-dispatcher/service-discover/policies.json >/dev/null 2>&1
+# shellcheck disable=SC2181
 if [[ "$?" != "0" ]]; then
     consul acl policy update -no-merge -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/message-dispatcher/service-discover/policies.json
     if [[ "$?" != "0" ]]; then
@@ -56,6 +53,7 @@ fi
 trap 'echo Script for Message Dispatcher terminated with error' EXIT
 set -e
 
+config_variant "auth"
 config_variant "http"
 config_variant "xmpp"
 
@@ -93,6 +91,7 @@ sed "s/<db-password>/$DB_PASSWORD/" /etc/carbonio/message-dispatcher/mongooseim.
 get_consul_kv "${MAIN_SERVICE_NAME}/api/username" >/dev/null 2>&1; API_USERNAME=$CONSUL_VALUE
 if [[ "$API_USERNAME" == "" ]]; then
   consul kv put "${MAIN_SERVICE_NAME}/api/username" "${MAIN_SERVICE_NAME}"
+  # shellcheck disable=SC2181
   if [[ $? != 0 ]]; then
     echo "Cannot put a key value pair in Consul"
     exit 1
@@ -104,11 +103,13 @@ sed "s/<api-username>/$API_USERNAME/" /etc/carbonio/message-dispatcher/mongoosei
 get_consul_kv "${MAIN_SERVICE_NAME}/api/password" >/dev/null 2>&1; API_PASSWORD=$CONSUL_VALUE
 if [[ "$API_PASSWORD" == "" ]]; then
   openssl rand -hex 16 | tr -d '\n' | consul kv put "${MAIN_SERVICE_NAME}/api/password" -
+  # shellcheck disable=SC2181
   if [[ $? != 0 ]]; then
     echo "Cannot put a key value pair in Consul"
     exit 1
   fi
   get_consul_kv "${MAIN_SERVICE_NAME}/api/password" >/dev/null 2>&1; API_PASSWORD=$CONSUL_VALUE
+  # shellcheck disable=SC2181
   if [[ $? != 0 ]]; then
     echo "Cannot get a key value pair in Consul"
     exit 1
@@ -121,15 +122,15 @@ consul reload
 # Limit token visibility as much as possible
 export -n CONSUL_HTTP_TOKEN
 
-echo "======================================================================================="
+echo "==========================================================================================="
 echo "Carbonio Message Dispatcher correctly set!"
 echo "You must run carbonio-message-dispatcher-migration to check database consistency."
 echo "Syntax: [PGPASSWORD=password] carbonio-message-dispatcher-migration username [host] [port]"
-echo "======================================================================================="
+echo "==========================================================================================="
 
 systemctl restart carbonio-message-dispatcher-auth.service
 systemctl restart carbonio-message-dispatcher.service
+systemctl restart carbonio-message-dispatcher-auth-sidecar.service
 systemctl restart carbonio-message-dispatcher-http-sidecar.service
 systemctl restart carbonio-message-dispatcher-xmpp-sidecar.service
-systemctl restart carbonio-message-dispatcher-auth-sidecar.service
 trap - EXIT

--- a/package/carbonio-message-dispatcher-setup.sh
+++ b/package/carbonio-message-dispatcher-setup.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-only
-
-/usr/bin/carbonio-message-dispatcher setup

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.message.dispatcher</groupId>
   <artifactId>carbonio-message-dispatcher</artifactId>
-  <version>0.14.1</version>
+  <version>0.14.2</version>
 
   <modules>
     <module>carbonio-message-dispatcher-auth</module>


### PR DESCRIPTION
- Updated PKGBUILD to install jar under /usr/share/carbonio
- Renamed setup scripts and created a separated script to launch jar
instead of launching it directly from service
- Upgraded package version to 0.14.2 (align version from main branch)

refs: WSC-1268